### PR TITLE
Add frontend interactive dashboard stats card functionality

### DIFF
--- a/src/api/TabsApi.ts
+++ b/src/api/TabsApi.ts
@@ -123,5 +123,19 @@ export const TabsApi = {
                 success: false
             };
         }
+    },
+
+    // Get members with active tabs
+    getActiveMembersWithTabs: async (): Promise<ApiResponse<any[]>> => {
+        try {
+            const response = await apiClient.get('/tabs/active-members');
+            return { data: response.data, success: true };
+        } catch (error) {
+            const err = error as Error;
+            return {
+                error: err.message || 'Failed to fetch active members with tabs',
+                success: false
+            };
+        }
     }
 };

--- a/src/components/MemberList/MemberList.tsx
+++ b/src/components/MemberList/MemberList.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, ChangeEvent } from 'react';
 import { Member } from '../../types/Member';
 import MemberCard from './MemberCard'; // Use adapted MemberCard
 import { IcafeApi } from '../../api/icafeApi';
+import { TabsApi } from '../../api/TabsApi';
 import LoadingSpinner from '../common/LoadingSpinner';
 import ErrorMessage from '../common/ErrorMessage';
 import { Search, Users } from 'lucide-react'; // Icons
@@ -11,15 +12,27 @@ import { useWebSocket } from '../../contexts/WebSocketContext';
 interface MemberListProps {
   onMemberSelect: (member: Member) => void;
   selectedMemberId?: number; // Keep this prop to indicate selection
+  showActiveTabsOnly?: boolean; // New prop to control view mode
+  onViewModeChange?: (showActiveTabsOnly: boolean) => void; // Callback for view mode changes
 }
 
-const MemberList: React.FC<MemberListProps> = ({ onMemberSelect, selectedMemberId }) => {
+const MemberList: React.FC<MemberListProps> = ({ 
+  onMemberSelect, 
+  selectedMemberId, 
+  showActiveTabsOnly = false,
+  onViewModeChange 
+}) => {
   const { members: webSocketMembers, isConnected } = useWebSocket();
   const [members, setMembers] = useState<Member[]>([]);
   const [filteredMembers, setFilteredMembers] = useState<Member[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  
+  // State for active tab members
+  const [activeTabMembers, setActiveTabMembers] = useState<any[]>([]);
+  const [activeTabsLoading, setActiveTabsLoading] = useState<boolean>(false);
+  const [activeTabsError, setActiveTabsError] = useState<string | null>(null);
 
   // Fetching logic with WebSocket integration
   const fetchMembers = async () => {
@@ -40,6 +53,25 @@ const MemberList: React.FC<MemberListProps> = ({ onMemberSelect, selectedMemberI
       console.error(err);
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Fetch active tab members
+  const fetchActiveTabMembers = async () => {
+    setActiveTabsLoading(true);
+    setActiveTabsError(null);
+    try {
+      const response = await TabsApi.getActiveMembersWithTabs();
+      if (response.success && response.data) {
+        setActiveTabMembers(response.data);
+      } else {
+        setActiveTabsError(response.error || 'Failed to fetch active tab members');
+      }
+    } catch (err) {
+      setActiveTabsError('An unexpected error occurred');
+      console.error(err);
+    } finally {
+      setActiveTabsLoading(false);
     }
   };
 
@@ -93,6 +125,20 @@ const MemberList: React.FC<MemberListProps> = ({ onMemberSelect, selectedMemberI
     filterMembers(searchQuery, members);
   }, [searchQuery, members]);
 
+  // Fetch active tab members when showActiveTabsOnly is true
+  useEffect(() => {
+    if (showActiveTabsOnly) {
+      fetchActiveTabMembers();
+    }
+  }, [showActiveTabsOnly]);
+
+  // Reset to show all members when starting to search
+  useEffect(() => {
+    if (searchQuery.trim() && showActiveTabsOnly && onViewModeChange) {
+      onViewModeChange(false);
+    }
+  }, [searchQuery, showActiveTabsOnly, onViewModeChange]);
+
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
   };
@@ -104,6 +150,49 @@ const MemberList: React.FC<MemberListProps> = ({ onMemberSelect, selectedMemberI
 
   // Render Content
   const renderContent = () => {
+    // Show active tabs view when enabled and no search query
+    if (showActiveTabsOnly && !searchQuery.trim()) {
+      if (activeTabsLoading) {
+        return <div className="flex justify-center items-center flex-grow"><LoadingSpinner message="Loading active tabs..." /></div>;
+      }
+      if (activeTabsError) {
+        return <div className="p-4 flex-grow"><ErrorMessage message={activeTabsError} onRetry={fetchActiveTabMembers} /></div>;
+      }
+      if (activeTabMembers.length === 0) {
+        return (
+          <div className="text-center py-6 text-gray-500 flex-grow flex flex-col items-center justify-center">
+            <Users size={40} className="mb-3 text-gray-400"/>
+            <p className="text-sm">No members with active tabs</p>
+          </div>
+        );
+      }
+      return (
+        <div className="space-y-1 p-2 overflow-y-auto flex-grow">
+          {activeTabMembers.map((activeTabMember) => (
+            <MemberCard
+              key={activeTabMember.memberId}
+              member={{
+                member_id: activeTabMember.memberId,
+                member_account: activeTabMember.memberAccount,
+                member_first_name: '',
+                member_last_name: '',
+                member_balance: '',
+                member_is_active: 1
+              }}
+              isSelected={selectedMemberId === activeTabMember.memberId}
+              onClick={(member) => handleMemberClick(member)}
+              tabInfo={{
+                totalAmount: activeTabMember.totalAmount,
+                itemCount: activeTabMember.itemCount,
+                pcName: activeTabMember.pcName
+              }}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    // Regular member list view
     if (loading) {
         return <div className="flex justify-center items-center flex-grow"><LoadingSpinner message="Loading members..." /></div>;
     }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -33,11 +33,17 @@ interface StatCardProps {
   icon: React.ReactNode;
   color: string; // Tailwind bg color class e.g., 'bg-blue-500'
   percentage?: number; // Make percentage optional
+  onClick?: () => void; // Add optional click handler
 }
 
-const StatCard: React.FC<StatCardProps> = ({ title, value, subtitle, icon, color, percentage }) => {
+const StatCard: React.FC<StatCardProps> = ({ title, value, subtitle, icon, color, percentage, onClick }) => {
   return (
-    <div className="bg-white rounded-lg shadow-sm p-4 border border-gray-100">
+    <div 
+      className={`bg-white rounded-lg shadow-sm p-4 border border-gray-100 ${
+        onClick ? 'cursor-pointer hover:shadow-md transition-shadow duration-200' : ''
+      }`}
+      onClick={onClick}
+    >
       <div className="flex items-start justify-between mb-3">
         <div>
           <h3 className="text-sm font-medium text-gray-500">{title}</h3>
@@ -83,6 +89,9 @@ const Dashboard: React.FC = () => {
   const [isCreatingTab, setIsCreatingTab] = useState<boolean>(false); // Loading state for POST /tabs
   const [isClosingTab, setIsClosingTab] = useState<boolean>(false);   // Loading state for POST /tabs/:id/close
   const [tabError, setTabError] = useState<string | null>(null);     // Errors related to tab operations
+  
+  // State for member list view mode
+  const [showActiveTabsOnly, setShowActiveTabsOnly] = useState<boolean>(false);
 
   // --- Data Fetching ---
   const fetchInitialData = useCallback(async () => {
@@ -277,6 +286,11 @@ const Dashboard: React.FC = () => {
     setActiveTab(updatedTab); // Update the active tab state
   };
 
+  // Handler for clicking on "PCs with Tabs" stat card
+  const handleTabsStatClick = () => {
+    setShowActiveTabsOnly(true);
+  };
+
 
   // --- Derived Data & Calculations ---
   const calculateStats = useCallback(() => {
@@ -357,6 +371,7 @@ const Dashboard: React.FC = () => {
           icon={<ShoppingCart size={20} />}
           color="bg-purple-500"
           percentage={pcsLoading ? 0 : (stats.totalPCs > 0 ? Math.round((stats.pcsWithTabs / stats.totalPCs) * 100) : 0)}
+          onClick={handleTabsStatClick}
         />
       </div>
 
@@ -392,8 +407,8 @@ const Dashboard: React.FC = () => {
             <MemberList
               onMemberSelect={handleMemberSelect}
               selectedMemberId={selectedMember?.member_id}
-            // Pass members data and loading states if MemberList handles its own fetching,
-            // otherwise, ensure MemberList can receive `members`, `membersLoading`, `membersError` as props
+              showActiveTabsOnly={showActiveTabsOnly}
+              onViewModeChange={setShowActiveTabsOnly}
             />
           </div>
 


### PR DESCRIPTION
- Make 'PCs with Tabs' stats card clickable to show active tab members
- Modify MemberList to support showing active tab members by default
- Add API integration for fetching members with active tabs
- Implement view mode switching between active tabs and search results
- Show tab information (amount, item count, PC name) in member cards